### PR TITLE
Lab 2 

### DIFF
--- a/Python/Flask_Book_Library/project/customers/models.py
+++ b/Python/Flask_Book_Library/project/customers/models.py
@@ -22,7 +22,7 @@ class Customer(db.Model):
         print("Getting: " + str(self),flush=True)
 
     def __repr__(self):
-        return f"Customer(ID: {self.id}, Name: {self.name}, City: {self.city}, Age: {self.age}, Pesel: {self.pesel}, Street: {self.street}, AppNo: {self.appNo})"
+        return f"Customer(ID: {self.id}, Name: {self.name}, City: {self.city}, Age: {self.age}, Pesel: {'*' * len(self.pesel)}, Street: {'*' * len(self.street)}, AppNo: {'*' * len(self.appNo)})"
 
 
 with app.app_context():


### PR DESCRIPTION
## Zadanie 1

### Podatność

Przy tworzeniu nowego klienta w zakładce `Customers` użytkownik musi podać m.in adres jak i PESEL. Logi aplikacji zawierają owe dane bez zamaskowania co może prowadzić do wycieku.

**Miejsce wprowadzenia danych**
![leak](https://github.com/Ruadhri17/task2/assets/59620198/503b419a-2711-4a96-a8f0-ee0e259c2e48)

**Logi po dodaniu danych **
![leak1](https://github.com/Ruadhri17/task2/assets/59620198/583c61c7-1b63-4ab7-8537-837e737abf12)

### Rozwiązanie
Zastosowałem maskowanie danych poprzez zastąpienie każdego ze znaków `*`, dzięki czemu dane podczas odczytu logów pozostają nieznane dla trzeciego odbiorcy.

**Logi po poprawce**
> Info: dane takie same jak przy wykryciu poprawki
![leak2](https://github.com/Ruadhri17/task2/assets/59620198/5ce01858-9e43-4077-9076-0910b98cf2f6)

## Zadanie 2

Zadanie drugie polegało na wykryciu sekretów, które nieumyślnie mogły znaleźć się w commitach repozytorium. 
Skan został uruchomiony przy pomocy komendy:
```
docker run -v ${folder_path}:/path zricethezav/gitleaks:latest detect --source="/path" -v
```
gdzie `folder_path` to miejsce w którym przechowywane jest repozytorium na stacji roboczej.

Poniżej wynik skanu programu `gitleaks`:

```
Finding:     -----BEGIN RSA PRIVATE KEY-----                                 
MIIBOgIBAAJBAKj34GkxFhD90vcNLYLInFEX6Ppy1tPf9Cnzj4p4WGeKLs1Pt8Qu
KUp...                                                          
Secret:      -----BEGIN RSA PRIVATE KEY-----                                 
MIIBOgIBAAJBAKj34GkxFhD90vcNLYLInFEX6Ppy1tPf9Cnzj4p4WGeKLs1Pt8Qu
KUp...                                                          
RuleID:      private-key
Entropy:     5.877638
File:        deployment.key
Line:        1
Commit:      bc17b7ddc46f46fff175aed55d68e11bb48166cc
Author:      Grzegorz Siewruk
Email:       gsiewruk@gmail.com
Date:        2023-11-15T12:52:32Z
Fingerprint: bc17b7ddc46f46fff175aed55d68e11bb48166cc:deployment.key:private-key:1

Finding:     -----BEGIN RSA PRIVATE KEY-----                                 
MIIBOgIBAAJBAKj34GkxFhD90vcNLYLInFEX6Ppy1tPf9Cnzj4p4WGeKLs1Pt8Qu
KUp...                                                          
Secret:      -----BEGIN RSA PRIVATE KEY-----                                 
MIIBOgIBAAJBAKj34GkxFhD90vcNLYLInFEX6Ppy1tPf9Cnzj4p4WGeKLs1Pt8Qu
KUp...                                                          
RuleID:      private-key
Entropy:     5.877638
File:        deployment2.key
Line:        1
Commit:      de9d7b8cb63bd7ae741ec5c9e23891b71709bc28
Author:      Grzegorz Siewruk
Email:       gsiewruk@gmail.com
Date:        2023-11-15T12:49:39Z
Fingerprint: de9d7b8cb63bd7ae741ec5c9e23891b71709bc28:deployment2.key:private-key:1

Finding:     "private_key": "-----BEGIN PRIVATE KEY-----\nlRsGbRO/1A5LiQHjuR5SASDASDAiSMNeOYqna2R+HEalBoyISASDASD1Tgkj\n4CC02Uux+...-\n",
Secret:      -----BEGIN PRIVATE KEY-----\nlRsGbRO/1A5LiQHjuR5SASDASDAiSMNeOYqna2R+HEalBoyISASDASD1Tgkj\n4CC02Uux+...
RuleID:      private-key
Entropy:     5.917220
File:        awscredentials.json
Line:        5
Commit:      bc17b7ddc46f46fff175aed55d68e11bb48166cc
Author:      Grzegorz Siewruk
Email:       gsiewruk@gmail.com
Date:        2023-11-15T12:52:32Z
Fingerprint: bc17b7ddc46f46fff175aed55d68e11bb48166cc:awscredentials.json:private-key:5

Finding:     "private_key_id": "002ac3c1623rdewc7bb13f6b10e6"
Secret:      002ac3c1623rdewc7bb13f6b10e6
RuleID:      generic-api-key
Entropy:     3.645593
File:        awscredentials.json
Line:        4
Commit:      bc17b7ddc46f46fff175aed55d68e11bb48166cc
Author:      Grzegorz Siewruk
Email:       gsiewruk@gmail.com
Date:        2023-11-15T12:52:32Z
Fingerprint: bc17b7ddc46f46fff175aed55d68e11bb48166cc:awscredentials.json:generic-api-key:4

8:24PM INF 6 commits scanned.
8:24PM INF scan completed in 421ms
8:24PM WRN leaks found: 4
```

### Wyniki

Zostały znalezione 4 podatności w 2 commitach i obejmowały następujące pliki:

1. [deployment.key](https://github.com/Ruadhri17/task2/blob/bc17b7ddc46f46fff175aed55d68e11bb48166cc/deployment.key)
2. [deployment2.key](https://github.com/Ruadhri17/task2/blob/de9d7b8cb63bd7ae741ec5c9e23891b71709bc28/deployment2.key)
3. [awscredentials.json](https://github.com/Ruadhri17/task2/blob/bc17b7ddc46f46fff175aed55d68e11bb48166cc/awscredentials.json)

3 z 4 podatności zostały wskazane prawidłowo i obejmowały one wyciek kluczy prywatnych. Jeden z nich obejmował ID klucza prywatnego, który nie stanowi zagrożenia i można go uznać za false positive.  

### Przechowywanie sekretów w repozytorium
W przypadku wykrycia wysłania sekretów do publicznego repozytorium należy natychmiastowo wymienić dane na nowe. Sekrety nie powinny być częścią repozytorium. Należy przechowywać je lokalnie w pliku i upewnić się, że plik znajduje się w `.gitignore`.

## Zadanie 3
Zadanie polegało na znalezieniu podatności w bibliotekach open-source. W tym celu  wykorzystano [pyupio](https://hub.docker.com/r/pyupio/safety). Wynik skanowania można znaleźć poniżej:
```
+==============================================================================+
|                                                                              |
|                               /$$$$$$            /$$                         |
|                              /$$__  $$          | $$                         |
|           /$$$$$$$  /$$$$$$ | $$  \__//$$$$$$  /$$$$$$   /$$   /$$           |
|          /$$_____/ |____  $$| $$$$   /$$__  $$|_  $$_/  | $$  | $$           |
|         |  $$$$$$   /$$$$$$$| $$_/  | $$$$$$$$  | $$    | $$  | $$           |
|          \____  $$ /$$__  $$| $$    | $$_____/  | $$ /$$| $$  | $$           |
|          /$$$$$$$/|  $$$$$$$| $$    |  $$$$$$$  |  $$$$/|  $$$$$$$           |
|         |_______/  \_______/|__/     \_______/   \___/   \____  $$           |
|                                                          /$$  | $$           |
|                                                         |  $$$$$$/           |
|  by pyup.io                                              \______/            |
|                                                                              |
+==============================================================================+
| REPORT                                                                       |
| checked 18 packages, using free DB (updated once a month)                    |
+============================+===========+==========================+==========+
| package                    | installed | affected                 | ID       |
+============================+===========+==========================+==========+
| healpy                     | 1.8.0     | <=1.16.6                 | 61774    |
+==============================================================================+
| Healpy 1.16.6 and prior releases ship with a version of 'libcurl' that has a |
| high-severity vulnerability.                                                 |
+==============================================================================+
```
### Podatność

Została znaleziona  jedna podatność dla biblioteki `healpy`, która obowiązuje dla wersji `<=1.16.6` i dotyczy ona dołączonej do `healpy`  biblioteki `libcurl`, która ma podatność określoną na `high-severity`. W tym konkretnym przypadku podatność była powodowana przez przepełnienie buffora sterty podczas  `SOCKS5 proxy handshake`, co mogło prowadzić do wycieku danych przy odpowiednio spreparowanym URL. Więcej informacji o podatności można znaleźć [tutaj](https://curl.se/docs/CVE-2023-38545.html).

### Rozwiązanie
Jako rozwiązanie twórcy zalecają użycie jednej z podanych metod:
* Update biblioteki do wersji `8.4.0`
* Zastosowanie patcha do obecnie używanej wersji
* Nieużywanie `CURLPROXY_SOCKS5_HOSTNAME` proxy przy pomocy curl'a.
* Nieustawianie `socks5h://` jako environment variable

W przypadku naszego projektu `healpy` nie jest używany więc wystarczy po prostu usunąć go z listy `requirements-task.txt`. Jeżeli planowane jest użycie biblioteki `healpy` należy niezwłocznie przeprowadzić update do wersji co najmniej `1.16.6`. 